### PR TITLE
Support use_modular_headers! option in Podfile

### DIFF
--- a/BLWebSocketsServer.podspec
+++ b/BLWebSocketsServer.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/benlodotcom/BLWebSocketsServer.git", :tag => "0.1.0" }
   s.platform     = :ios, '5.0'
   s.source_files = 'BLWebSocketsServer', 'BLWebSocketsServer/libwebsockets'
+  s.public_header_files = ['BLWebSocketsServer/BLWebSocketsServer.h']
   s.library   = 'z'
   s.requires_arc = true
 end


### PR DESCRIPTION
If we use `use_modular_headers!` in Podfile we have all headers in modulemap. This change allow to leave only one public header `BLWebSocketsServer.h`